### PR TITLE
Telemetry signal crash handling 

### DIFF
--- a/Client/Cliqz/Foundation/Networking/ConnectionManager.swift
+++ b/Client/Cliqz/Foundation/Networking/ConnectionManager.swift
@@ -82,8 +82,7 @@ class ConnectionManager {
                         }
                 }
             } catch let error as NSError {
-                DebugLogger.log("Sending request with the following body \(body), failed with error: \(error)")
-                Answers.logCustomEventWithName("sendPostRequestException", customAttributes: nil)
+                Answers.logCustomEventWithName("sendPostRequestError", customAttributes: ["error": error.localizedDescription])
             }
         } else {
             Answers.logCustomEventWithName("sendPostRequestError", customAttributes: nil)

--- a/Client/Cliqz/Frontend/Browser/JavaScriptBridge.swift
+++ b/Client/Cliqz/Frontend/Browser/JavaScriptBridge.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Shared
+import Crashlytics
 
 @objc protocol JavaScriptBridgeDelegate: class {
     
@@ -111,7 +112,17 @@ class JavaScriptBridge {
             
         case "pushTelemetry":
             if let telemetrySignal = data as? [String: AnyObject] {
-                TelemetryLogger.sharedInstance.logEvent(.JavaScriptsignal(telemetrySignal))
+                if NSJSONSerialization.isValidJSONObject(telemetrySignal) {
+                    TelemetryLogger.sharedInstance.logEvent(.JavaScriptsignal(telemetrySignal))
+                } else {
+                    var customAttributes = [String: AnyObject]()
+                    
+                    if let action = telemetrySignal["action"],
+                        let type = telemetrySignal["type"] {
+                            customAttributes = ["acion": action,"type": type]
+                    }
+                    Answers.logCustomEventWithName("InvalidJavaScriptTelemetrySignal", customAttributes: customAttributes)
+                }
             }
             
         case "copyResult":


### PR DESCRIPTION
- Serialize telemetry signals as JSON object instead of using NSKeyedArchiver 
- Handle exceptions to make it log to Crashlytics instead of crashing the app
