### PR TITLE
 Add Crashlytics logging to LocalDataStore

### DIFF
--- a/Client/Cliqz/Foundation/Data Structures/LocalDataStore.swift
+++ b/Client/Cliqz/Foundation/Data Structures/LocalDataStore.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Crashlytics
 
 class LocalDataStore {
     static let defaults = NSUserDefaults.standardUserDefaults()
@@ -14,6 +15,10 @@ class LocalDataStore {
     static let dispatchQueue = dispatch_get_main_queue()
 
     class func setObject(value: AnyObject?, forKey: String) {
+        
+        // [TO_BE_REMOVED] Add logging to get more details to identify why the app crashes when dealing with NSUserDefaults
+        CLSLogv("[LocalDataStore] setObjectForKey: %@", getVaList([forKey]))
+        
         dispatch_async(dispatchQueue) {
             defaults.setObject(value, forKey: forKey)
             defaults.synchronize()
@@ -25,6 +30,9 @@ class LocalDataStore {
     }
     
     class func removeObjectForKey(key: String) {
+        // [TO_BE_REMOVED] Add logging to get more details to identify why the app crashes when dealing with NSUserDefaults
+        CLSLogv("[LocalDataStore] removeObjectForKey: %@", getVaList([key]))
+        
         dispatch_async(dispatchQueue) {
             defaults.removeObjectForKey(key)
             defaults.synchronize()


### PR DESCRIPTION
Add Crashlytics logging to LocalDataStore to get more details to identify why the app crashes when dealing with NSUserDefaults
