### PR TITLE
Telemetry Signals

### DIFF
--- a/Client/Cliqz/Foundation/Environment/AppStatus.swift
+++ b/Client/Cliqz/Foundation/Environment/AppStatus.swift
@@ -53,7 +53,6 @@ class AppStatus {
 
     //MARK:- pulbic interface
     internal func appWillFinishLaunching() {
-		TelemetryLogger.sharedInstance.logEvent(.AppStateChange("will_finish_launch"))
         
         lastOpenedDate = NSDate()
         NetworkReachability.sharedInstance.startMonitoring()
@@ -61,7 +60,6 @@ class AppStatus {
     }
 
     internal func appDidFinishLaunching() {
-        TelemetryLogger.sharedInstance.logEvent(.AppStateChange("did_finish_launch"))
         
         dispatch_async(dispatchQueue) {
             
@@ -84,15 +82,12 @@ class AppStatus {
     }
     
     internal func appWillEnterForeground() {
+        
         SessionState.sessionResumed()
-        
-        TelemetryLogger.sharedInstance.logEvent(.AppStateChange("will_enter_foreground"))
-        
         lastOpenedDate = NSDate()
     }
     
     internal func appDidBecomeActive(profile: Profile) {
-        TelemetryLogger.sharedInstance.logEvent(.AppStateChange("did_become_active"))
         
         NetworkReachability.sharedInstance.refreshStatus()
         logApplicationUsageEvent("Active")
@@ -110,7 +105,6 @@ class AppStatus {
     }
     
     internal func appWillResignActive() {
-        TelemetryLogger.sharedInstance.logEvent(.AppStateChange("will_resign_active"))
         
         logApplicationUsageEvent("Inactive")
         NetworkReachability.sharedInstance.logNetworkStatusEvent()
@@ -119,8 +113,6 @@ class AppStatus {
     internal func appDidEnterBackground() {
         SessionState.sessionPaused()
         
-        TelemetryLogger.sharedInstance.logEvent(.AppStateChange("did_enter_background"))
-        
         let timeUsed = NSDate.milliSecondsSinceDate(lastOpenedDate)
         logApplicationUsageEvent("Background", startupType:nil, startupTime: nil, timeUsed: timeUsed)
         TelemetryLogger.sharedInstance.storeCurrentTelemetrySeq()
@@ -128,7 +120,6 @@ class AppStatus {
 	}
 
     internal func appWillTerminate() {
-        TelemetryLogger.sharedInstance.logEvent(.AppStateChange("will_terminate"))
         
         logApplicationUsageEvent("Terminate")
     }

--- a/Client/Cliqz/Foundation/Logging/TelemetryLogger.swift
+++ b/Client/Cliqz/Foundation/Logging/TelemetryLogger.swift
@@ -23,6 +23,7 @@ public enum TelemetryLogEventType {
     case JavaScriptSignal   ([String: AnyObject])
 	case LocationServicesStatus (String, String?)
     case HomeScreenShortcut (String, Int)
+    case TabSignal          (String, String, Int?, Int)
     
 }
 
@@ -112,6 +113,9 @@ class TelemetryLogger : EventsLogger {
                 
             case .HomeScreenShortcut(let targetType, let targetIndex):
                 event = self.createHomeScreenShortcutEvent(targetType, targetIndex: targetIndex)
+            
+            case .TabSignal(let action, let mode, let tabIndex, let tabCount):
+                event = self.createTabSignalEvent(action, mode: mode, tabIndex: tabIndex, tabCount: tabCount)
                 
             }
             
@@ -345,5 +349,18 @@ class TelemetryLogger : EventsLogger {
         event["target_index"] = targetIndex
         return event
     }
+    
+    private func createTabSignalEvent(action: String, mode: String, tabIndex: Int?, tabCount: Int) -> [String: AnyObject] {
+        var event = createBasicEvent()
+        event["type"] = "tab"
+        event["action"] = action
+        event["mode"] = mode
+        if let index = tabIndex {
+            event["tab_index"] = index
+        }
+        event["tab_count"] = tabCount
+        return event
+    }
+    
     
 }

--- a/Client/Cliqz/Foundation/Logging/TelemetryLogger.swift
+++ b/Client/Cliqz/Foundation/Logging/TelemetryLogger.swift
@@ -24,8 +24,6 @@ public enum TelemetryLogEventType {
 	case LocationServicesStatus (String, String?)
     case HomeScreenShortcut (String, Int)
     
-    //TODO: to be removed as it was added for testing
-    case AppStateChange      (String)
 }
 
 
@@ -115,9 +113,6 @@ class TelemetryLogger : EventsLogger {
             case .HomeScreenShortcut(let targetType, let targetIndex):
                 event = self.createHomeScreenShortcutEvent(targetType, targetIndex: targetIndex)
                 
-            //TODO: to be removed as it was added for testing
-            case .AppStateChange(let transition):
-                event = self.createAppStateChangeEvent(transition)
             }
             
             // Always store the event
@@ -348,16 +343,6 @@ class TelemetryLogger : EventsLogger {
         event["action"] = "click"
         event["target_type"] = targetType
         event["target_index"] = targetIndex
-        return event
-    }
-
-    //TODO: to be removed as it was added for testing
-    private func createAppStateChangeEvent(transition: String) -> [String: AnyObject] {
-        var event = createBasicEvent()
-        
-        event["type"] = "app_state_transition"
-        event["transition"] = transition
-
         return event
     }
     

--- a/Client/Cliqz/Foundation/Logging/TelemetryLogger.swift
+++ b/Client/Cliqz/Foundation/Logging/TelemetryLogger.swift
@@ -20,7 +20,7 @@ public enum TelemetryLogEventType {
     case PastTap            (String, Int, Double, Double, Double)
     case Navigation         (String, Int, Int, Double)
     case ResultEnter        (Int, Int, String?, Double, Double)
-    case JavaScriptsignal   ([String: AnyObject])
+    case JavaScriptSignal   ([String: AnyObject])
 	case LocationServicesStatus (String, String?)
     case HomeScreenShortcut (String, Int)
     
@@ -104,7 +104,7 @@ class TelemetryLogger : EventsLogger {
             case .ResultEnter(let queryLength, let autocompletedLength, let autocompletedUrl, let reactionTime, let urlbarTime):
                 event = self.createResultEnterEvent(queryLength, autocompletedLength: autocompletedLength, autocompletedUrl: autocompletedUrl, reactionTime: reactionTime, urlbarTime: urlbarTime)
                 
-            case .JavaScriptsignal(let javaScriptSignal):
+            case .JavaScriptSignal(let javaScriptSignal):
                 event = self.creatJavaScriptSignalEvent(javaScriptSignal)
 			
             case .LocationServicesStatus(let action, let status):

--- a/Client/Cliqz/Frontend/Browser/JavaScriptBridge.swift
+++ b/Client/Cliqz/Frontend/Browser/JavaScriptBridge.swift
@@ -113,7 +113,7 @@ class JavaScriptBridge {
         case "pushTelemetry":
             if let telemetrySignal = data as? [String: AnyObject] {
                 if NSJSONSerialization.isValidJSONObject(telemetrySignal) {
-                    TelemetryLogger.sharedInstance.logEvent(.JavaScriptsignal(telemetrySignal))
+                    TelemetryLogger.sharedInstance.logEvent(.JavaScriptSignal(telemetrySignal))
                 } else {
                     var customAttributes = [String: AnyObject]()
                     

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -390,6 +390,9 @@ class TabTrayController: UIViewController {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELappWillResignActiveNotification", name: UIApplicationWillResignActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELappDidBecomeActiveNotification", name: UIApplicationDidBecomeActiveNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "SELDynamicFontChanged:", name: NotificationDynamicFontChanged, object: nil)
+        
+        // Cliqz: log open menu telemetry signal
+        tabManager.logTabTelemetrySignal("open_menu", isPrivate: privateMode, tabIndex: nil)
     }
 
     override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
@@ -514,6 +517,9 @@ class TabTrayController: UIViewController {
             }
             self.collectionView.alpha = 1
         }
+        
+        // Cliqz: log switch mode telemetry signal
+        tabManager.logTabTelemetrySignal("switch_mode", isPrivate: privateMode, tabIndex: nil)
     }
 
     @available(iOS 9, *)


### PR DESCRIPTION
- Removed dummy `AppStateChange` telemetry signal  
- Renamed `JavaScriptsignal` to `JavaScriptSignal` to match camel case standard
- Implemented telemetry signals for Tabs
