### PR TITLE
Disabled scrolling in search web view

### DIFF
--- a/Client/Cliqz/Frontend/Browser/CliqzSearchViewController.swift
+++ b/Client/Cliqz/Frontend/Browser/CliqzSearchViewController.swift
@@ -68,7 +68,8 @@ class CliqzSearchViewController : UIViewController, LoaderListener, WKNavigation
         let config = ConfigurationManager.sharedInstance.getSharedConfiguration(self)
 
         self.webView = WKWebView(frame: self.view.bounds, configuration: config)
-		self.webView?.navigationDelegate = self;
+		self.webView?.navigationDelegate = self
+        self.webView?.scrollView.scrollEnabled = false
         self.view.addSubview(self.webView!)
         
 		self.spinnerView = UIActivityIndicatorView(activityIndicatorStyle: UIActivityIndicatorViewStyle.Gray)


### PR DESCRIPTION
Disabled scrolling in search web view to prevent swiping glitches in JavaScript when user drag the card off the screen
