### PR TITLE
Preserve the search state when switching between tabs

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -68,6 +68,12 @@ class Browser: NSObject, BrowserWebViewDelegate {
     /// browser instance, queue it for later until we become foregrounded.
     private var alertQueue = [JSAlertInfo]()
 
+    // Cliqz: preserve lastsearch query when moving out of browser view while search in progress
+    var lastSearchQuery = ""
+    
+    // Cliqz: flag to know whether the current tab is in search mode or not
+    var inSearchMode = true
+    
     init(configuration: WKWebViewConfiguration) {
         self.configuration = configuration
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1323,8 +1323,14 @@ extension BrowserViewController: URLBarDelegate {
 
         let tabTrayController = TabTrayController(tabManager: tabManager, profile: profile, tabTrayDelegate: self)
 
+        // Cliqz: Take screenshot of search view instead of browser view if tabs button is clicked while search is in progress
+//        screenshotHelper.takeScreenshot(tab)
         if let tab = tabManager.selectedTab {
-            screenshotHelper.takeScreenshot(tab)
+            if searchController?.view.hidden == false {
+                screenshotHelper.takeScreenshot(tab, searchView: searchController!.view)
+            } else {
+                screenshotHelper.takeScreenshot(tab)
+            }
         }
 
         self.navigationController?.pushViewController(tabTrayController, animated: true)

--- a/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -56,4 +56,11 @@ class ScreenshotHelper {
             takeDelayedScreenshot(tab)
         }
     }
+    
+    // Cliqz: Take screenshot of search view instead of browser view if tabs button is clicked while search is in progress
+    func takeScreenshot(tab: Browser, searchView: UIView) {
+        var screenshot: UIImage?
+        screenshot = searchView.screenshot()
+        tab.setScreenshot(screenshot)
+    }
 }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -159,8 +159,6 @@ class TabManager : NSObject {
         assert(NSThread.isMainThread())
 
         if selectedTab === tab {
-            // Cliqz: post notification when swithcing back to the previous tab
-            NSNotificationCenter.defaultCenter().postNotificationName(NotificationSwitchedToPreviousTab, object: nil)
             return
         }
 

--- a/Utils/NotificationConstants.swift
+++ b/Utils/NotificationConstants.swift
@@ -17,6 +17,3 @@ public let NotificationDataRemoteLoginChangesWereApplied = "NotificationDataRemo
 
 // Cliqz: Fired when trying to clear local history
 public let NotificationPrivateDataClearQueries = "PrivateDataClearQueriesNotification"
-
-// Cliqz: Fired when switching back again to the previous selected tab
-public let NotificationSwitchedToPreviousTab = "SwitchedToPreviousTabNotification"


### PR DESCRIPTION
Preserve the search state when switching between tabs and take screen shot of search view instead of browser view in case tabs button is clicked while search is in progress
