### PR TITLE
Fixed clear private data on termination and handled corner cases for hiding webview overlaty

### DIFF
--- a/Client/Cliqz/Frontend/Browser/JavaScriptBridge.swift
+++ b/Client/Cliqz/Frontend/Browser/JavaScriptBridge.swift
@@ -20,6 +20,7 @@ import WebKit
     optional func getSearchHistoryResults(callback: String?)
     optional func shareCard(cardURL: String)
     optional func autoCompeleteQuery(autoCompleteText: String)
+    optional func isReady()
 }
 
 class JavaScriptBridge {
@@ -163,6 +164,8 @@ class JavaScriptBridge {
             if let ids = data as? [Int] {
                 self.profile.history.removeHistory(ids)
             }
+        case "isReady":
+            delegate?.isReady?()
         default:
 			print("Unhandles JS action")
 //            print("Unhandles JS action: \(action), with data: \(data)")

--- a/Client/Cliqz/Frontend/Browser/SearchHistoryViewController.swift
+++ b/Client/Cliqz/Frontend/Browser/SearchHistoryViewController.swift
@@ -91,15 +91,7 @@ class SearchHistoryViewController: UIViewController, WKNavigationDelegate, WKScr
     
     // Mark: Navigation delegate
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
-		guard NSUserDefaults.standardUserDefaults().boolForKey(IsAppTerminated) ?? false else {
-			return
-		}
-		guard let profile = self.profile where (profile.prefs.boolForKey(ClearDataOnTerminatingPrefKey) ?? false) == true && profile.historyTypeShouldBeCleared() != .None else {
-			return
-		}
-		clearQueries(includeFavorites: profile.historyTypeShouldBeCleared() == .All)
-		NSUserDefaults.standardUserDefaults().setBool(false, forKey: IsAppTerminated)
-		NSUserDefaults.standardUserDefaults().synchronize()
+		
     }
     
     func webView(webView: WKWebView, didFailNavigation navigation: WKNavigation!, withError error: NSError) {
@@ -195,6 +187,17 @@ extension SearchHistoryViewController: JavaScriptBridgeDelegate {
         }
     }
     
+    func isReady() {
+        guard NSUserDefaults.standardUserDefaults().boolForKey(IsAppTerminated) ?? false else {
+            return
+        }
+        guard let profile = self.profile where (profile.prefs.boolForKey(ClearDataOnTerminatingPrefKey) ?? false) == true && profile.historyTypeShouldBeCleared() != .None else {
+            return
+        }
+        clearQueries(includeFavorites: profile.historyTypeShouldBeCleared() == .All)
+        NSUserDefaults.standardUserDefaults().setBool(false, forKey: IsAppTerminated)
+        NSUserDefaults.standardUserDefaults().synchronize()
+    }
     
     // MARK: - Clear History
 	func clearQueries(notification: NSNotification) {

--- a/Client/Cliqz/Frontend/Browser/SearchHistoryViewController.swift
+++ b/Client/Cliqz/Frontend/Browser/SearchHistoryViewController.swift
@@ -76,7 +76,7 @@ class SearchHistoryViewController: UIViewController, WKNavigationDelegate, WKScr
         super.viewDidAppear(animated)
         if self.reload == true {
             self.reload = false;
-            self.getSearchHistoryResults("showHistory")
+            self.getSearchHistoryResults("History.showHistory")
 		}
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2396,12 +2396,18 @@ extension BrowserViewController: WKUIDelegate {
             currentResponseStatusCode = response.statusCode
         }
         
+        // Cliqz: hide overlay after webview delay as some links does not call didFinishNavigation
+        let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(2 * Double(NSEC_PER_SEC)))
+        dispatch_after(delayTime, dispatch_get_main_queue()) {
+            self.hideWebViewOverlay()
+        }
+        
         if navigationResponse.canShowMIMEType {
             decisionHandler(WKNavigationResponsePolicy.Allow)
             return
         }
 
-        let error = NSError(domain: ErrorPageHelper.MozDomain, code: Int(ErrorPageHelper.MozErrorDownloadsNotEnabled), userInfo: [NSLocalizedDescriptionKey: "Downloads aren't supported in Firefox yet (but we're working on it)."])
+        let error = NSError(domain: ErrorPageHelper.MozDomain, code: Int(ErrorPageHelper.MozErrorDownloadsNotEnabled), userInfo: [NSLocalizedDescriptionKey: "Downloads aren't supported in CLIQZ yet (but we're working on it)."])
         ErrorPageHelper().showPage(error, forUrl: navigationResponse.response.URL!, inWebView: webView)
         decisionHandler(WKNavigationResponsePolicy.Allow)
     }


### PR DESCRIPTION
Fixed clear private data on termination and handled corner cases for hiding webview overlaty
