### PR TITLE
Copied AdBlocker files from bundle to documents directory when required

### DIFF
--- a/Client/Cliqz/Foundation/Extensions/StringExtension.swift
+++ b/Client/Cliqz/Foundation/Extensions/StringExtension.swift
@@ -16,7 +16,7 @@ extension String {
     
     
     func trim() -> String {
-        let newString = self.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+        let newString = self.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
         return newString
     }
     


### PR DESCRIPTION
Copied AdBlocker files from bundle to documents directory when required (fresh installed, or upgrading to new build of Navigation Extension)