### PR TITLE
Quick fixes for 1.0.6 release

### DIFF
--- a/Client/Cliqz/Frontend/Browser/CliqzIntroViewController.swift
+++ b/Client/Cliqz/Frontend/Browser/CliqzIntroViewController.swift
@@ -70,6 +70,14 @@ class CliqzIntroViewController: UIViewController {
         
     }
     
+    override func shouldAutorotate() -> Bool {
+        return false
+    }
+    
+    override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.Portrait
+    }
+
     private func setupConstraints() {
         cliqzLogoView.snp_makeConstraints { make in
             make.centerX.equalTo(self.view)

--- a/Client/Cliqz/Frontend/Resources/main.js
+++ b/Client/Cliqz/Frontend/Resources/main.js
@@ -181,7 +181,7 @@ System.register('yt-downloader/main', [], function (_export) {
       FORMAT_LABEL = { '5': 'FLV 240p', '18': 'MP4 360p', '22': 'MP4 720p', '34': 'FLV 360p', '35': 'FLV 480p', '37': 'MP4 1080p', '38': 'MP4 2160p', '43': 'WebM 360p', '44': 'WebM 480p', '45': 'WebM 720p', '46': 'WebM 1080p', '135': 'MP4 480p - no audio', '137': 'MP4 1080p - no audio', '138': 'MP4 2160p - no audio', '139': 'M4A 48kbps - audio', '140': 'M4A 128kbps - audio', '141': 'M4A 256kbps - audio', '264': 'MP4 1440p - no audio', '266': 'MP4 2160p - no audio', '298': 'MP4 720p60 - no audio', '299': 'MP4 1080p60 - no audio' };
       FORMAT_TYPE = { '5': 'flv', '18': 'mp4', '22': 'mp4', '34': 'flv', '35': 'flv', '37': 'mp4', '38': 'mp4', '43': 'webm', '44': 'webm', '45': 'webm', '46': 'webm', '135': 'mp4', '137': 'mp4', '138': 'mp4', '139': 'm4a', '140': 'm4a', '141': 'm4a', '264': 'mp4', '266': 'mp4', '298': 'mp4', '299': 'mp4' };
       FORMAT_ORDER = ['5', '18', '34', '43', '35', '135', '44', '22', '298', '45', '37', '299', '46', '264', '38', '266', '139', '140', '141'];
-      FORMAT_RULE = { 'flv': 'none', 'mp4': 'all', 'webm': 'max', 'm4a': 'max' };
+      FORMAT_RULE = { 'flv': 'none', 'mp4': 'all', /*'webm': 'max',*/ 'm4a': 'max' };
 
       // all = display all versions, max = only highest quality version, none = no version
       // the default settings show all MP4 videos, the highest quality FLV and no WebM

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -3394,6 +3394,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 let newTabTitle = NSLocalizedString("Open In New Tab", comment: "Context menu item for opening a link in a new tab")
                 let openNewTabAction =  UIAlertAction(title: newTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                     self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
+                        self.preserveSearchState()
                         self.tabManager.addTab(NSURLRequest(URL: url))
                         TelemetryLogger.sharedInstance.logEvent(.ContextMenu("new_tab", "link"))
                     })
@@ -3408,6 +3409,7 @@ extension BrowserViewController: ContextMenuHelperDelegate {
                 
                 let openNewPrivateTabAction =  UIAlertAction(title: openNewPrivateTabTitle, style: UIAlertActionStyle.Default) { (action: UIAlertAction) in
                     self.scrollController.showToolbars(animated: !self.scrollController.toolbarsShowing, completion: { _ in
+                        self.preserveSearchState()
                         self.tabManager.addTab(NSURLRequest(URL: url), isPrivate: true)
                         TelemetryLogger.sharedInstance.logEvent(.ContextMenu("new_forget_tab", "link"))
                     })


### PR DESCRIPTION
Fixed interface orientation for on-boarding, and preserved the tab search state before opening a link into a new tab from the context menu
@naira-cliqz 