### PR TITLE
Fix selection of unsupported region when getting location from config API

### DIFF
--- a/Client/Cliqz/Frontend/Browser/FreshtabViewController.swift
+++ b/Client/Cliqz/Frontend/Browser/FreshtabViewController.swift
@@ -224,7 +224,9 @@ class FreshtabViewController: UIViewController, UIGestureRecognizerDelegate {
         
         Alamofire.request(.GET, configUrl, parameters: nil, encoding: .JSON, headers: nil).responseJSON { (response) in
             if response.result.isSuccess {
-                if let location = response.result.value!["location"] as? String {
+                if let location = response.result.value!["location"] as? String, backends = response.result.value!["backends"] as? [String]
+                where backends.contains(location) {
+                    
                     self.region = location.uppercaseString
                     SettingsPrefs.updateRegionPref(self.region!)
                     self.loadNews()


### PR DESCRIPTION
@naira-cliqz  this bug I found in when I opened the app here as it selects `EG` in the settings