### PR TITLE
Enable react hot-reload without breaking jsbridge

### DIFF
--- a/Client/Cliqz/Foundation/AntiTracking/AntiTrackingModule.swift
+++ b/Client/Cliqz/Foundation/AntiTracking/AntiTrackingModule.swift
@@ -70,7 +70,7 @@ class AntiTrackingModule: NSObject {
     
     //MARK: - Private Helpers
     private func getTabBlockingInfo(webViewId: Int) -> [NSObject : AnyObject]! {
-        let response = Engine.sharedInstance.jsbridge.callAction("getTrackerListForTab", args: [webViewId])
+        let response = Engine.sharedInstance.getBridge().callAction("getTrackerListForTab", args: [webViewId])
         print(response)
         if let result = response["result"] {
             return result as? Dictionary

--- a/Client/Cliqz/Foundation/AntiTracking/InterceptorURLProtocol.swift
+++ b/Client/Cliqz/Foundation/AntiTracking/InterceptorURLProtocol.swift
@@ -28,7 +28,7 @@ class InterceptorURLProtocol: NSURLProtocol {
             return true
         }
         
-        if let blockResponse = Engine.sharedInstance.webRequest?.shouldBlockRequest(request) where blockResponse == true {
+        if Engine.sharedInstance.getWebRequest().shouldBlockRequest(request) == true {
             
             BlockedRequestsCache.sharedInstance.addBlockedRequest(request)
             

--- a/Client/Cliqz/Foundation/JSEngine/Engine.swift
+++ b/Client/Cliqz/Foundation/JSEngine/Engine.swift
@@ -12,10 +12,6 @@ import React
 
 public class Engine {
     
-    //MARK: - Instant variables
-    public var webRequest: WebRequest?
-    public let jsbridge: JSBridge
-    
     //MARK: - Singleton
     static let sharedInstance = Engine()
     
@@ -32,8 +28,14 @@ public class Engine {
         
         rootView = RCTRootView( bundleURL: jsCodeLocation, moduleName: "ExtensionApp", initialProperties: nil, launchOptions: nil )
         bridge = rootView.bridge
-        webRequest = bridge.moduleForClass(WebRequest) as? WebRequest
-        jsbridge = bridge.moduleForClass(JSBridge) as! JSBridge
+    }
+    
+    public func getBridge() -> JSBridge {
+        return bridge.moduleForClass(JSBridge) as! JSBridge
+    }
+    
+    public func getWebRequest() -> WebRequest {
+        return bridge.moduleForClass(WebRequest) as! WebRequest
     }
     
     //MARK: - Public APIs
@@ -50,11 +52,11 @@ public class Engine {
     }
     
     func setPref(prefName: String, prefValue: Any) {
-        self.jsbridge.callAction("setPref", args: [prefName, prefValue as! NSObject])
+        self.getBridge().callAction("setPref", args: [prefName, prefValue as! NSObject])
     }
     
     func getPref(prefName: String) -> Any {
-        let result = self.jsbridge.callAction("getPref", args: [prefName])
+        let result = self.getBridge().callAction("getPref", args: [prefName])
         return result["result"]
     }
     

--- a/Client/Cliqz/Foundation/JSEngine/JSBridge.swift
+++ b/Client/Cliqz/Foundation/JSEngine/JSBridge.swift
@@ -16,6 +16,7 @@ public class JSBridge : RCTEventEmitter {
     var actionCounter: NSInteger = 0
     var replyCache = [NSInteger: [String: NSObject]]()
     var eventSemaphores = [NSInteger: dispatch_semaphore_t]()
+    let ACTION_TIMEOUT : Int64 = 200000000 // 200ms
     
     public override init() {
         super.init()
@@ -49,7 +50,7 @@ public class JSBridge : RCTEventEmitter {
         self.sendEventWithName("callAction", body: ["id": actionId, "action": functionName, "args": args])
         
         // wait for the semaphore
-        let timeout = dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER)
+        let timeout = dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, self.ACTION_TIMEOUT))
 
         // after signal the reply should be ready in the cache
         objc_sync_enter(self.eventSemaphores)

--- a/Client/Cliqz/Foundation/JSEngine/WebRequest.swift
+++ b/Client/Cliqz/Foundation/JSEngine/WebRequest.swift
@@ -42,7 +42,7 @@ public class WebRequest : RCTEventEmitter {
             }
         }
         
-        let response = Engine.sharedInstance.jsbridge.callAction("webRequest", args: [requestInfo])
+        let response = Engine.sharedInstance.getBridge().callAction("webRequest", args: [requestInfo])
         if let blockResponse = response["result"] as? NSDictionary where blockResponse.count > 0 {
             print("xxxxx -> block \(request.URLString)")
             // update unsafe requests count for the webivew that issued this request

--- a/Client/Cliqz/Frontend/Browser/WebView/CliqzWebView.swift
+++ b/Client/Cliqz/Frontend/Browser/WebView/CliqzWebView.swift
@@ -342,7 +342,7 @@ class CliqzWebView: UIWebView {
 		delegate = self
         scalesPageToFit = true
         generateUniqueUserAgent()
-        Engine.sharedInstance.webRequest?.newTabCreated(self.uniqueId, webView: self)
+        Engine.sharedInstance.getWebRequest().newTabCreated(self.uniqueId, webView: self)
 		progress = WebViewProgress(parent: self)
 		let refresh = UIRefreshControl()
 		refresh.bounds = CGRectMake(0, -10, refresh.bounds.size.width, refresh.bounds.size.height)


### PR DESCRIPTION
This PR prevents the wrong bridge instance from being used after react reloads itself. The `jsbridge` member of `Engine` is replaced by a `getBridge` method, which always loads the correct instance from the react-native bridge.

@naira-cliqz @timotei-cliqz 