### PR TITLE
Updated react-native publishing

### DIFF
--- a/Client/Cliqz/Foundation/JSEngine/Engine.swift
+++ b/Client/Cliqz/Foundation/JSEngine/Engine.swift
@@ -20,12 +20,12 @@ open class Engine {
     //MARK: - Init
     public init() {
         #if React_Debug
-            let jsCodeLocation = URL(string: "http://192.168.3.184:8081/index.ios.bundle?platform=ios")
+            let jsCodeLocation = URL(string: "http://localhost:8081/index.ios.bundle?platform=ios")
         #else
             let jsCodeLocation = Bundle.main.url(forResource: "jsengine.bundle", withExtension: "js")
         #endif
         
-        rootView = RCTRootView( bundleURL: jsCodeLocation, moduleName: "ExtensionApp", initialProperties: nil, launchOptions: nil )
+        rootView = RCTRootView( bundleURL: jsCodeLocation, moduleName: "ConversationUI", initialProperties: nil, launchOptions: nil )
         bridge = rootView.bridge
     }
     

--- a/downloadJSEngine.sh
+++ b/downloadJSEngine.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-JSENGINE_RELEASE=ci
+JSENGINE_RELEASE=ci_b2
 PLATFORM=ios
 
 # when jsengine is in navigation-extenion, we can pull tags from there. In the meantime we'll

--- a/downloadJSEngine.sh
+++ b/downloadJSEngine.sh
@@ -5,16 +5,14 @@ PLATFORM=ios
 # when jsengine is in navigation-extenion, we can pull tags from there. In the meantime we'll
 # put them on cdn.cliqz.com
 BASE_RELEASE_URL=https://s3.amazonaws.com/cdn.cliqz.com/mobile/jsengine
-BUNDLE_NAME=jsengine.bundle.$PLATFORM.$JSENGINE_RELEASE
-PACKAGEJSON_PATH=package.json.$PLATFORM.$JSENGINE_RELEASE
+BUNDLE_NAME=jsengine.$PLATFORM.$JSENGINE_RELEASE.tar.gz
 
 # enter JSEngine directory
 mkdir -p ./JSEngine && cd ./JSEngine
 
-curl -O $BASE_RELEASE_URL/$BUNDLE_NAME.gz
-curl -O $BASE_RELEASE_URL/$PACKAGEJSON_PATH
-gunzip ./$BUNDLE_NAME.gz -d && mv $BUNDLE_NAME jsengine.bundle.js
-mv $PACKAGEJSON_PATH package.json
+curl -O $BASE_RELEASE_URL/$BUNDLE_NAME
+tar -xf $BUNDLE_NAME
+rm $BUNDLE_NAME
 
 # install react dependencies
 npm install


### PR DESCRIPTION
Changes to the way we pull in the react-native bundle to reflect changes from https://github.com/cliqz/navigation-extension/pull/3555

`assets` are now included in the published bundle.

@naira-cliqz @timotei-cliqz 