### PR TITLE
Implement CliqzEvent forwarding to native.

### DIFF
--- a/Client/Cliqz/Foundation/JSEngine/JSBridge.swift
+++ b/Client/Cliqz/Foundation/JSEngine/JSBridge.swift
@@ -47,6 +47,15 @@ open class JSBridge : RCTEventEmitter {
         return ["callAction", "publishEvent"]
     }
     
+    override open func constantsToExport() -> [String : Any]! {
+        return ["events": ["openUrl", "mobile-pairing:openTab",
+                           "mobile-pairing:downloadVideo",
+                           "mobile-pairing:pushPairingData",
+                           "mobile-pairing:notifyPairingError",
+                           "mobile-pairing:notifyPairingSuccess"]
+        ]
+    }
+    
     fileprivate func nextActionId() -> NSInteger {
         var nextId : NSInteger = 0
         lockDispatchQueue.sync {
@@ -181,7 +190,7 @@ open class JSBridge : RCTEventEmitter {
     
     
     @objc(pushEvent:data:)
-    func pushEvent(eventId: NSString, data: NSDictionary) {
+    func pushEvent(eventId: NSString, data: NSArray) {
         DispatchQueue.main.async() {
             NotificationCenter.default.post(name: NSNotification.Name(rawValue: eventId as String), object: data, userInfo: nil)
         }

--- a/Client/Cliqz/Foundation/JSEngine/JSBridgeBridge.m
+++ b/Client/Cliqz/Foundation/JSEngine/JSBridgeBridge.m
@@ -12,6 +12,6 @@
 
 RCT_EXTERN_METHOD(replyToAction:(nonnull NSInteger *)actionId result:(NSDictionary *)result)
 RCT_EXTERN_METHOD(registerAction:)
-RCT_EXTERN_METHOD(pushEvent:(nonnull NSString *)eventId data:(NSDictionary *)data)
+RCT_EXTERN_METHOD(pushEvent:(nonnull NSString *)eventId data:(NSArray *)data)
 
 @end

--- a/Client/Cliqz/Frontend/Browser/Connect/ConnectManager.swift
+++ b/Client/Cliqz/Frontend/Browser/Connect/ConnectManager.swift
@@ -97,7 +97,7 @@ class ConnectManager: NSObject {
     }
     //MARK: - Private Helpers
     @objc private func updateConnections(notification: NSNotification) {
-        guard let pairingData = notification.object as? [String: AnyObject],  let devices = pairingData["devices"] as? [[String: String]] else {
+        guard let args = notification.object as? [AnyObject], let pairingData = args[0] as? [String: AnyObject], let devices = pairingData["devices"] as? [[String: String]] else {
             return
         }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/cliqz-oss/browser-ios#readme",
   "dependencies": {
-    "browser-core": "https://github.com/sammacbeth/browser-ios/releases/download/v8.0.3/browser-core-1.20.0.tgz",
+    "browser-core": "https://github.com/sammacbeth/browser-ios/releases/download/v8.0.4/browser-core-1.20.0.tgz",
     "pouchdb-adapter-react-native-sqlite": "1.0.3",
     "pouchdb-react-native": "6.1.26",
     "react": "16.0.0-alpha.12",


### PR DESCRIPTION
Subscribe to Cliqz events in native and push them to `NotificationCenter` api.

This changes the shape of the arguments passed to `pushEvent` to handle generic use-cases. We push all of the event args as an array. I've updated the use in mobile-pairing to reflect the changes. 
cc @alex-cliqz
