### PR TITLE
Upgrade extension to version 3.23.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import 'react-native/Libraries/Core/InitializeCore';
 import React from 'react';
-import { AppRegistry, StyleSheet, View, NativeModules } from 'react-native';
+import { AppRegistry, StyleSheet, View } from 'react-native';
 import { startup, components } from 'browser-core';
 import 'babel-polyfill';
 
@@ -9,20 +9,18 @@ const appStart = startup.then((app) => {
   global.app = app;
 });
 
-const styles = function () {
-  return StyleSheet.create({
-    container: {
-      flex: 1,
-      flexDirection: 'column',
-      backgroundColor: '#FFFFFF'
-    },
-  });
-};
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'column',
+    backgroundColor: 'transparent'
+  },
+});
 
 // wrapper for a component to add top padding on iOS
 function AppContainer(App, appStart) {
   return () => (
-    <View style={styles().container}>
+    <View style={styles.container}>
       <App appStart={appStart} />
     </View>
   );

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/cliqz-oss/browser-ios#readme",
   "dependencies": {
-    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/react-native/3.23.2/f001394fe76784c34c3cdd873f58b9bd8fbba4db.tgz",
+    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/react-native/3.23.4/3a488011d7c2c99a08fdac0118553555af8bd18b.tgz",
     "buffer": "5.0.7",
     "https-browserify": "1.0.0",
     "path-browserify": "0.0.0",


### PR DESCRIPTION
This version includes transparent background behind the cards,
it means that the react root view background should be set from
native side.
Please don't forget to handle different cases (e.g. forget tab)