### PR TITLE
Fixes for issues reported by Konark

### DIFF
--- a/Client/Cliqz/Foundation/Anti-Phishing/AntiPhishingDetector.swift
+++ b/Client/Cliqz/Foundation/Anti-Phishing/AntiPhishingDetector.swift
@@ -21,7 +21,13 @@ class AntiPhishingDetector: NSObject {
             completion(false)
             return
         }
-		let queue = DispatchQueue.global(priority: DispatchQueue.GlobalQueuePriority.background)
+        
+        if isDetectedPhishingURL(url) {
+            completion(true)
+            return
+        }
+        
+		let queue = DispatchQueue.global(qos: .background)
 		queue.async { 
 			AntiPhishingDetector.scanURL(url, queue: queue, completion: completion)
 		}

--- a/Client/Cliqz/Frontend/Browser/WebView/CliqzWebView.swift
+++ b/Client/Cliqz/Frontend/Browser/WebView/CliqzWebView.swift
@@ -57,7 +57,8 @@ var nullWKNavigation: WKNavigation = WKNavigation()
             }
             wv.lastTappedTime = nil
             if let _url = URL(string: url, relativeTo: current) {
-                getApp().browserViewController.openURLInNewTab(_url)
+                let isPrivate = getApp().browserViewController.tabManager.selectedTab?.isPrivate ?? false
+                getApp().browserViewController.openURLInNewTab(_url, isPrivate: isPrivate)
             }
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2833,13 +2833,6 @@ extension BrowserViewController: WKNavigationDelegate {
             return
         }
 
-		// Cliqz: display AntiPhishing Alert to warn the user of in case of anti-phishing website
-		AntiPhishingDetector.isPhishingURL(url) { (isPhishingSite) in
-			if isPhishingSite {
-				self.showAntiPhishingAlert(url.host!)
-			}
-		}
-
         // Fixes 1261457 - Rich text editor fails because requests to about:blank are blocked
         if url.scheme == "about" {
             decisionHandler(WKNavigationActionPolicy.allow)
@@ -2884,6 +2877,17 @@ extension BrowserViewController: WKNavigationDelegate {
             UIApplication.shared.openURL(url)
             decisionHandler(WKNavigationActionPolicy.cancel)
             return
+        }
+        
+        
+        // Cliqz: display AntiPhishing Alert to warn the user of in case of anti-phishing website
+        // Cliqz: (Tim) - Antiphising should only check the mainDocumentURL.
+        if navigationAction.request.mainDocumentURL == url, let host = url.host {
+            AntiPhishingDetector.isPhishingURL(url) { (isPhishingSite) in
+                if isPhishingSite {
+                    self.showAntiPhishingAlert(host)
+                }
+            }
         }
         
         // This is the normal case, opening a http or https url, which we handle by loading them in this WKWebView. We


### PR DESCRIPTION
Forget Tab is supposed to open links that want to open in a new tab, in a Forget Tab.
Anti phishing should only check the mainDocumentURL. 